### PR TITLE
Issue 98

### DIFF
--- a/styles/readtheorg/js/readtheorg.js
+++ b/styles/readtheorg/js/readtheorg.js
@@ -1,3 +1,23 @@
+function collapse_toc_elements_on_click (nav_li_a){
+    /*
+      When an `a' element in the TOC is clicked, it's  parent
+      `li' element's active attribute is toggled. This causes
+      the element to toggle between minimized and maximized
+      states. The active attribute is documented in bootstrap.
+      https://getbootstrap.com/docs/4.0/components/navbar/#nav
+    */
+    $(nav_li_el).parent().toggleClass("active");
+}
+
+$( document ).ready(function() {
+    // when the document is loaded and ready, bind the
+    // function `collapse_toc_elements_on_click' to the
+    // `a' elements in the table of contents.
+    $("#text-table-of-contents a").click(function() {
+	collapse_toc_elements_on_click(this);
+    });
+});
+
 $(function() {
     $('.note').before("<p class='admonition-title note'>Note</p>");
     $('.seealso').before("<p class='admonition-title seealso'>See also</p>");

--- a/styles/readtheorg/js/readtheorg.js
+++ b/styles/readtheorg/js/readtheorg.js
@@ -7,6 +7,7 @@ function collapse_toc_elements_on_click (nav_li_a){
       https://getbootstrap.com/docs/4.0/components/navbar/#nav
     */
     $(nav_li_a).parent().toggleClass("active");
+	$("#text-table-of-contents li").removeClass("active");
 }
 
 $( document ).ready(function() {

--- a/styles/readtheorg/js/readtheorg.js
+++ b/styles/readtheorg/js/readtheorg.js
@@ -6,8 +6,8 @@ function collapse_toc_elements_on_click (nav_li_a){
       states. The active attribute is documented in bootstrap.
       https://getbootstrap.com/docs/4.0/components/navbar/#nav
     */
-    $(nav_li_a).parent().toggleClass("active");
 	$("#text-table-of-contents li").removeClass("active");
+    $(nav_li_a).parents().toggleClass("active");
 }
 
 $( document ).ready(function() {

--- a/styles/readtheorg/js/readtheorg.js
+++ b/styles/readtheorg/js/readtheorg.js
@@ -6,7 +6,7 @@ function collapse_toc_elements_on_click (nav_li_a){
       states. The active attribute is documented in bootstrap.
       https://getbootstrap.com/docs/4.0/components/navbar/#nav
     */
-    $(nav_li_el).parent().toggleClass("active");
+    $(nav_li_a).parent().toggleClass("active");
 }
 
 $( document ).ready(function() {


### PR DESCRIPTION
This merge fixes #98 on base repo

When elements in the table of contents are clicked in readtheorg
theme, the children are toggled. This is similar behavior to readthedocs,
but without the +/- buttons.