### PR TITLE
Removed background so the blob goes away

### DIFF
--- a/styles/readtheorg/css/readtheorg.css
+++ b/styles/readtheorg/css/readtheorg.css
@@ -428,7 +428,6 @@ table tr:nth-child(2n) td{
     }
 
     #toggle-sidebar {
-        background-color: #2980B9;
         display: block;
         margin-bottom: 1.6em;
         padding: 0.6em;


### PR DESCRIPTION
Remove the background color for #toggle-sidebar element because on
smaller screens the toggle div looks aweful, like some blob that was
misplaced.